### PR TITLE
Fix to remove erroneous error when clicking Deploy

### DIFF
--- a/sharepoint.html
+++ b/sharepoint.html
@@ -74,7 +74,7 @@
 	  },
       serviceUri: {
         value: '',
-        required: true
+        required: false
       }
   },
     inputs: 1,


### PR DESCRIPTION
This field does not need to be required if msg.spURL is passed in.